### PR TITLE
Do not insert prototypes in the middle of a line.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -197,10 +197,7 @@ public:
 
         FullSourceLoc first = undeclaredIdentifiers.back()->location;
         if (first.isBeforeInTranslationUnitThan(begin)) {
-            if (debugOutput) {
-                outs() << "  !! Insertion point found!\n";
-            }
-            insertionPointFound = true;
+            markInsertionPointAsFound();
             return;
         }
 
@@ -216,10 +213,22 @@ public:
         }
 
         if (first.isBeforeInTranslationUnitThan(end)) {
+            markInsertionPointAsFound();
+        }
+    }
+
+    void markInsertionPointAsFound() {
+        if (debugOutput) {
+            outs() << "  !! Insertion point found at ";
+            outs() << insertionPoint.getSpellingLineNumber() << ":" << insertionPoint.getSpellingColumnNumber() << "\n";
+        }
+        insertionPointFound = true;
+
+        if (insertionPoint.getSpellingColumnNumber() != 1) {
             if (debugOutput) {
-                outs() << "  !! Insertion point found!\n";
+                outs() << "     Insertion point is not at the line beginning -> adding a newline\n";
             }
-            insertionPointFound = true;
+            rewriter.InsertTextAfter(insertionPoint, "\n");
         }
     }
 

--- a/testsuite/testdata/test_issue_7.cpp
+++ b/testsuite/testdata/test_issue_7.cpp
@@ -1,0 +1,9 @@
+// https://github.com/arduino/arduino-preprocessor/issues/7
+
+#line 1 "issue_7.ino"
+
+int a; int b=f();
+
+int f() {
+  return 1;
+}


### PR DESCRIPTION
The insertion point of prototypes may be detected to be in the middle of a line for example in the following sketch:

```c++
int a; int b=forwardDeclared();
void setup() {}
void loop() {}
int forwardDeclared() { return 0; }
```

the insertion point is determined to be between `int a;` and `int b=..` since the latter declaration use a forward-declared function to initialize variable.
Before this patch this resulted in a stray `#line` directive inserted in the middle of a line:

```c++
int a; #line 1 ......     <- added prototype line
int forwardDeclared();    <- added prototype
#line 2.....              <- other prototypes....
......
```

This patch avoids the situation above by inserting a newline just before the first `#line` directive if the insertion point happens to be in the middle of a line.

Fix #7