### PR TITLE
Add support for powerpc64le systems

### DIFF
--- a/package-arduino-preprocessor.bash
+++ b/package-arduino-preprocessor.bash
@@ -73,6 +73,9 @@ if [[ $OS == "GNU/Linux" ]] ; then
   elif [[ $MACHINE == "armv7l" ]] ; then
     OUTPUT_TAG=armhf-pc-linux-gnu
     fetch_llvm https://github.com/cmaglie/llvm-clang-build-scripts/releases/download/4.0.0/llvm-clang-4.0.0-linux-arm.tar.xz
+  elif [[ $MACHINE == "ppc64le" ]] ; then
+    OUTPUT_TAG=powerpc64le-pc-linux-gnu
+    fetch_llvm https://github.com/cmaglie/llvm-clang-build-scripts/releases/download/4.0.0/llvm-clang-4.0.0-linux-powerpc64le.tar.xz
   else
     echo Linux Machine not supported: $MACHINE
     exit 1


### PR DESCRIPTION
There are no prebuilt packages available for ppc64el (OpenPOWER) systems, despite the software working on those platforms.

OpenPOWER systems are being deployed more widely, especially in education, and having an easy way to install a newer IDE version than the 1.5 version in Debian Experimental would be much appreciated.

As mentioned in https://github.com/cmaglie/llvm-clang-build-scripts/issues/1 , I can provide a prebuilt binary on request for publication if that is easiest.

See also arduino/Arduino#8778